### PR TITLE
Make getCurrentSong return nil if list is empty

### DIFF
--- a/player.go
+++ b/player.go
@@ -67,7 +67,11 @@ type Queue struct {
 }
 
 func (q *Queue) getCurrentSong() *Song {
-	return q.songlist[q.currentSong]
+	if len(q.songlist) != 0 {
+		return q.songlist[q.currentSong]
+	} else {
+		return nil
+	}
 }
 
 func (q *Queue) addSong(song *Song) {


### PR DESCRIPTION
Prevents out of bound errors, such as "deleting" a song from an empty queue.